### PR TITLE
Fixed gulp-zip semver to 3.0.2 to prevent https://github.com/sindreso…

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "del": "^2.0.0",
     "gulp": "^3.9.0",
     "gulp-install": "^0.5.0",
-    "gulp-zip": "^3.0.2",
+    "gulp-zip": "3.0.2",
     "node-aws-lambda": "^0.1.5"
   }
 }


### PR DESCRIPTION
Using ^3.0.2 as the semver for gulp-zip causes lambdas packaged on Windows to fail to run due to directories not having the execute bit set.

Fixing to 3.0.2 until this issue is fixed in gulp-zip as this resolves the issue.
