### PR TITLE
Add ability to update relative paths for local packages in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,15 @@ In your repository :
  * deploy (the full process) is given in the example above (but customizable)
 
 
+## Handling local modules
 
+If your project includes local modules and they are included in package.json using a relative path (_e.g._ `'my-helper-module': "file:../my-helper-module"`) then the node-mods task will fail to run `npm install` correctly as these modules are no longer resolvable from within the dist folder.
+
+To rectify this situation the module import takes a second parameter `options` which can be used to fix-up these relative paths in the package.json as it being copied to dist/, so changing the `require` to:
+````js
+require('aws-lambda-gulp-tasks')(gulp, { fixRelativePackages: true });
+````
+in your gulpfile.js will ensure the `gulp deploy` works as expected.
 
 # License
 

--- a/index.js
+++ b/index.js
@@ -4,9 +4,11 @@ var gulp = require('gulp'),
     del = require('del'),
     install = require('gulp-install'),
     awsLambda = require('node-aws-lambda'),
-    path = require('path');
+    path = require('path'),
+    replace = require('gulp-replace'),
+    gulpif = require('gulp-if');
 
-module.exports = function(gulp) {
+module.exports = function(gulp, options) {
 
   gulp.task('clean', function(cb) {
     return del(['./dist', './dist.zip'], cb);
@@ -19,6 +21,7 @@ module.exports = function(gulp) {
 
   gulp.task('node-mods', function() {
     return gulp.src('./package.json')
+      .pipe(gulpif(options && options.fixRelativePackages, replace(/file:\.\.([\\/]+)/g, 'file:..$1..$1')))
       .pipe(gulp.dest('dist/'))
       .pipe(install({production: true}));
   });
@@ -32,5 +35,5 @@ module.exports = function(gulp) {
   gulp.task('upload', function(callback) {
     awsLambda.deploy('./dist.zip', require( path.join(process.cwd(), "lambda-config.js") ), callback);
   });
-
+    
 };

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "aws-sdk": "^2.1.45",
     "del": "^2.0.0",
     "gulp": "^3.9.0",
+    "gulp-if": "^2.0.0",
     "gulp-install": "^0.5.0",
-    "gulp-zip": "^3.0.2",
+    "gulp-replace": "^0.5.4",
+    "gulp-zip": "^3.0.2",  
     "node-aws-lambda": "^0.1.5"
   }
 }


### PR DESCRIPTION
At present if the project included local modules using relative paths in package.json the deploy would fail at the npm install part of node-mods, as these modules would not be resolvable.

I've added an optional parameter to permit the user to specify that these should be modified as the file is in transit to the dist/ folder to allow the deploy to function
